### PR TITLE
Add database seeders and fix pivot table relation

### DIFF
--- a/laravel/app/Models/Actor.php
+++ b/laravel/app/Models/Actor.php
@@ -10,6 +10,6 @@ class Actor extends Model
 
     public function movies()
     {
-        return $this->belongsToMany(Movie::class);
+        return $this->belongsToMany(Movie::class, 'movie_actor');
     }
 }

--- a/laravel/app/Models/Movie.php
+++ b/laravel/app/Models/Movie.php
@@ -22,7 +22,7 @@ class Movie extends Model
 
     public function actors()
     {
-        return $this->belongsToMany(Actor::class);
+        return $this->belongsToMany(Actor::class, 'movie_actor');
     }
 
     public function pictures()

--- a/laravel/database/seeders/ActorSeeder.php
+++ b/laravel/database/seeders/ActorSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Actor;
+
+class ActorSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $actors = [
+            'Robert Downey Jr.',
+            'Scarlett Johansson',
+            'Chris Evans',
+            'Tom Holland',
+        ];
+
+        foreach ($actors as $name) {
+            Actor::firstOrCreate(['name' => $name]);
+        }
+    }
+}

--- a/laravel/database/seeders/DatabaseSeeder.php
+++ b/laravel/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,9 @@ namespace Database\Seeders;
 use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Database\Seeders\GenreSeeder;
+use Database\Seeders\ActorSeeder;
+use Database\Seeders\MovieSeeder;
 
 class DatabaseSeeder extends Seeder
 {
@@ -18,6 +21,12 @@ class DatabaseSeeder extends Seeder
         User::factory()->create([
             'name' => 'Test User',
             'email' => 'test@example.com',
+        ]);
+
+        $this->call([
+            GenreSeeder::class,
+            ActorSeeder::class,
+            MovieSeeder::class,
         ]);
     }
 }

--- a/laravel/database/seeders/GenreSeeder.php
+++ b/laravel/database/seeders/GenreSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Genre;
+
+class GenreSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $genres = [
+            'Action',
+            'Comedy',
+            'Drama',
+            'Science Fiction',
+        ];
+
+        foreach ($genres as $name) {
+            Genre::firstOrCreate(['name' => $name]);
+        }
+    }
+}

--- a/laravel/database/seeders/MovieSeeder.php
+++ b/laravel/database/seeders/MovieSeeder.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Movie;
+use App\Models\Genre;
+use App\Models\Actor;
+
+class MovieSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $movies = [
+            [
+                'title' => 'Avengers: Endgame',
+                'description' => 'Super heroes unite to battle Thanos.',
+                'genre' => 'Action',
+                'actors' => [
+                    'Robert Downey Jr.',
+                    'Scarlett Johansson',
+                    'Chris Evans',
+                ],
+                'pictures' => [
+                    'https://example.com/endgame1.jpg',
+                    'https://example.com/endgame2.jpg',
+                ],
+            ],
+            [
+                'title' => 'Iron Man',
+                'description' => 'Tony Stark becomes the armored hero.',
+                'genre' => 'Action',
+                'actors' => [
+                    'Robert Downey Jr.',
+                ],
+                'pictures' => [
+                    'https://example.com/ironman1.jpg',
+                ],
+            ],
+            [
+                'title' => 'Lucy',
+                'description' => 'A woman unlocks the full potential of her brain.',
+                'genre' => 'Science Fiction',
+                'actors' => [
+                    'Scarlett Johansson',
+                ],
+                'pictures' => [
+                    'https://example.com/lucy1.jpg',
+                ],
+            ],
+        ];
+
+        foreach ($movies as $data) {
+            $genre = Genre::firstOrCreate(['name' => $data['genre']]);
+
+            $movie = Movie::create([
+                'title' => $data['title'],
+                'description' => $data['description'],
+                'genre_id' => $genre->id,
+            ]);
+
+            $actorIds = [];
+            foreach ($data['actors'] as $name) {
+                $actor = Actor::firstOrCreate(['name' => $name]);
+                $actorIds[] = $actor->id;
+            }
+            $movie->actors()->sync($actorIds);
+
+            foreach ($data['pictures'] as $url) {
+                $movie->pictures()->create(['url' => $url]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- seed initial data for genres, actors, and movies
- call the new seeders from `DatabaseSeeder`
- specify pivot table name in `Actor` and `Movie` models

## Testing
- `composer install`
- `php artisan key:generate`
- `php artisan migrate:fresh --seed`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68767e475ee48322ab116313cee57dfd